### PR TITLE
AB#1723 - retry 504 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 5.0.2 2020-12-8
+
+### Changed
+
+- Retry `504` responses
+
 ## 5.0.1 2020-11-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-tenable-cloud",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "A JupiterOne managed integration for https://www.tenable.com/products/tenable-io",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-tenable-cloud",

--- a/src/tenable/TenableClient.ts
+++ b/src/tenable/TenableClient.ts
@@ -287,7 +287,7 @@ export default class TenableClient {
           return retryDelay;
         },
         handleError: (err, context) => {
-          if (err.statusCode !== 429 && err.statusCode !== 500) {
+          if (![429, 500, 504].includes(err.statusCode)) {
             context.abort();
           }
         },


### PR DESCRIPTION
504 errors happen when the resulting server is too slow to respond to your request. Seems like a good idea to just try again if we get them to see if their servers respond faster next time. It might make sense to wait a second or so as well, but seems unnecessary to me.