### PR TITLE
Improve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 5.0.4 - 2020-12-15
+
 ### Changed
 
 - Change client log levels from `trace` -> `info` and request log level from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Change client log levels from `trace` -> `info` and request log level from
+  `trace` -> `debug`.
+
 ## 5.0.3 - 2020-12-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-tenable-cloud",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "A JupiterOne managed integration for https://www.tenable.com/products/tenable-io",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-tenable-cloud",

--- a/src/executionHandler.test.ts
+++ b/src/executionHandler.test.ts
@@ -1,9 +1,6 @@
 import nock from "nock";
 
-import {
-  createTestIntegrationExecutionContext,
-  IntegrationInvocationEvent,
-} from "@jupiterone/jupiter-managed-integration-sdk";
+import { createTestIntegrationExecutionContext } from "@jupiterone/jupiter-managed-integration-sdk";
 
 import executionHandler from "./executionHandler";
 import * as Entities from "./jupiterone/entities";
@@ -121,28 +118,4 @@ describe("executionHandler", () => {
     expect(persister.publishEntityOperations).toHaveBeenCalledTimes(13);
     expect(persister.publishPersisterOperations).toHaveBeenCalledTimes(5);
   }, 60000);
-
-  test("action unknown", async () => {
-    const invocationContext = createTestIntegrationExecutionContext({
-      instance: {
-        config: tenableConfig,
-      },
-      event: {
-        action: {
-          name: "CREATE_ENTITY",
-        },
-      } as IntegrationInvocationEvent,
-    });
-
-    const { persister } = invocationContext.clients.getClients();
-    jest.spyOn(persister, "processEntities");
-    jest.spyOn(persister, "processRelationships");
-    jest.spyOn(persister, "publishPersisterOperations");
-
-    await executionHandler(invocationContext);
-
-    expect(persister.processEntities).not.toHaveBeenCalled();
-    expect(persister.processRelationships).not.toHaveBeenCalled();
-    expect(persister.publishPersisterOperations).not.toHaveBeenCalled();
-  });
 });

--- a/src/executionHandler.ts
+++ b/src/executionHandler.ts
@@ -39,12 +39,8 @@ import logObjectCounts from "./utils/logObjectCounts";
 export default async function executionHandler(
   context: IntegrationExecutionContext,
 ): Promise<IntegrationExecutionResult> {
-  const actionFunction = ACTIONS[context.event.action.name];
-  if (actionFunction) {
-    return await actionFunction(await initializeContext(context));
-  } else {
-    return {};
-  }
+  const initializedContext = await initializeContext(context);
+  return synchronize(initializedContext);
 }
 
 async function synchronize(
@@ -415,15 +411,3 @@ async function synchronizeHostVulnerabilities(
 
   return operations;
 }
-
-type ActionFunction = (
-  context: TenableIntegrationContext,
-) => Promise<IntegrationExecutionResult>;
-
-interface ActionMap {
-  [actionName: string]: ActionFunction | undefined;
-}
-
-const ACTIONS: ActionMap = {
-  INGEST: synchronize,
-};

--- a/src/tenable/TenableClient.test.ts
+++ b/src/tenable/TenableClient.test.ts
@@ -7,6 +7,19 @@ import {
   RecentScanSummary,
   ScanHostVulnerability,
 } from "./types";
+import { IntegrationLogger } from "@jupiterone/jupiter-managed-integration-sdk";
+
+function getIntegrationLogger(): IntegrationLogger {
+  return {
+    trace: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    fatal: jest.fn(),
+    child: () => getIntegrationLogger(),
+  }
+}
 
 const ACCESS_KEY =
   process.env.TENABLE_LOCAL_EXECUTION_ACCESS_KEY || "test_access_token";
@@ -21,7 +34,7 @@ function prepareScope(def: nock.NockDefinition) {
 
 function getClient() {
   return new TenableClient({
-    logger: { trace: jest.fn(), warn: jest.fn(), info: jest.fn() } as any,
+    logger: getIntegrationLogger(),
     accessToken: ACCESS_KEY,
     secretToken: SECRET_KEY,
     retryMaxAttempts: RETRY_MAX_ATTEMPTS,
@@ -31,7 +44,7 @@ function getClient() {
 describe("new TenableClient", () => {
   test("accepts 0 retryMaxAttempts", () => {
     const client = new TenableClient({
-      logger: { trace: jest.fn() } as any,
+      logger: getIntegrationLogger(),
       accessToken: ACCESS_KEY,
       secretToken: SECRET_KEY,
       retryMaxAttempts: 0,

--- a/src/tenable/TenableClient.ts
+++ b/src/tenable/TenableClient.ts
@@ -62,7 +62,7 @@ export default class TenableClient {
       Method.GET,
       {},
     );
-    this.logger.trace(
+    this.logger.info(
       { permissions: response.permissions },
       "Fetched Tenable user's permissions",
     );
@@ -75,7 +75,7 @@ export default class TenableClient {
       Method.GET,
       {},
     );
-    this.logger.trace(
+    this.logger.info(
       { users: length(usersResponse.users) },
       "Fetched Tenable users",
     );
@@ -88,8 +88,8 @@ export default class TenableClient {
       Method.GET,
       {},
     );
-    this.logger.trace(
-      { users: length(scansResponse.scans) },
+    this.logger.info(
+      { scans: length(scansResponse.scans) },
       "Fetched Tenable scans",
     );
     return scansResponse.scans;
@@ -107,7 +107,7 @@ export default class TenableClient {
 
       const { info, hosts, vulnerabilities } = scanResponse;
 
-      this.logger.trace(
+      this.logger.info(
         {
           scan: { id: scan.id, uuid: scan.uuid },
           hosts: length(hosts),
@@ -153,7 +153,7 @@ export default class TenableClient {
         {},
       );
 
-      this.logger.trace(logData, "Fetched Tenable asset vulnerability info");
+      this.logger.info(logData, "Fetched Tenable asset vulnerability info");
 
       return vulnerabilitiesResponse.info;
     } catch (err) {
@@ -176,7 +176,7 @@ export default class TenableClient {
       ScanVulnerabilitiesResponse
     >(`/scans/${scanId}/hosts/${hostId}`, Method.GET, {});
 
-    this.logger.trace(
+    this.logger.info(
       {
         scan: { id: scanId },
         host: { id: hostId },
@@ -195,7 +195,7 @@ export default class TenableClient {
       {},
     );
 
-    this.logger.trace(
+    this.logger.info(
       { assets: length(assetsResponse.assets) },
       "Fetched Tenable assets",
     );
@@ -210,7 +210,7 @@ export default class TenableClient {
       {},
     );
 
-    this.logger.trace(
+    this.logger.info(
       { containers: length(containersResponse) },
       "Fetched Tenable assets",
     );
@@ -227,7 +227,7 @@ export default class TenableClient {
       {},
     );
 
-    this.logger.trace(
+    this.logger.info(
       {
         digestId,
         malware: length(reportResponse.malware),
@@ -256,7 +256,7 @@ export default class TenableClient {
       },
     };
 
-    this.logger.trace({ method, url }, "Fetching Tenable data...");
+    this.logger.debug({ method, url }, "Fetching Tenable data...");
 
     let retryDelay = 0;
 
@@ -266,6 +266,10 @@ export default class TenableClient {
 
         if (response.status === 429) {
           const serverRetryDelay = response.headers.get("retry-after");
+          this.logger.info(
+            { serverRetryDelay, url },
+            "Received 429 response from endpoint; waiting to retry.",
+          );
           if (serverRetryDelay) {
             retryDelay = Number.parseInt(serverRetryDelay, 10) * 1000;
           }

--- a/src/tenable/TenableClient.ts
+++ b/src/tenable/TenableClient.ts
@@ -294,6 +294,15 @@ export default class TenableClient {
           if (![429, 500, 504].includes(err.statusCode)) {
             context.abort();
           }
+          this.logger.info(
+            {
+              url,
+              err,
+              attemptNum: context.attemptNum,
+              attemptsRemaining: context.attemptsRemaining,
+            },
+            "Encountered retryable API response. Retrying.",
+          );
         },
       },
     );


### PR DESCRIPTION
I set the log level=TRACE on infrastructure running this integration in order to expose logs about the API calls in this integration. However, the underlying SDK has a _ton_ of TRACE-level logging:

```
'_rawData not found'
'No changes detected'
'Found in old set'
'Calling handleSkippedDuplicate; Already seen in new set'
'[SKIP] - Relationships in new dataset have identical key'
'[SKIP] - Entities in new dataset have identical key'
'Calling diffRawData'
'_rawData deleted from item'
'Item _rawData differs from existing, keeping only changed properties'
'Calling handleUpdate'
'Calling uploadRawData'
'_rawData has changed'
'_rawData uploaded'
'Not found in new set, already marked _deleted'
'Calling handleDelete; Not found in new set'
'Executing raw query'
'Calling handleUpdate; No changes detected, undeleting'
```

While I was trying to expose ~380 API-related logs in this integration, setting the level to TRACE exposed over 23,000 logs in this integration.

The integration API log messages don't expose sensitive information, just counts and IDs. Bumping these levels will make keeping track of these logs much easier.

BONUS: I added a 429 retry log. This integration, when timing out, was waiting 3-5 minutes between API calls. I could not tell why that was happening but retrys could have been a factor.