### PR TITLE
Graph tenable cloud v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 6.0.0 - 2021-05-14
+
+### Changed
+
+- The integration no longer uses the `/workbenches/assets` endpoint to get
+  vulnerability information and now uses the asset export endpoint to get extra
+  asset metadata information.
+
+### Added
+
+- Bulk export endpoints for vulnerabilities and assets
+
 ## 5.3.0 - 2021-05-12
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-tenable-cloud",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "A JupiterOne managed integration for https://www.tenable.com/products/tenable-io",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-tenable-cloud",


### PR DESCRIPTION
This is the release of the bulk export changes, it should help alleviate rate limiting problems we've had with a couple of the endpoints.