### PR TITLE
Handle tenable 404 for host vulnerabilities

### DIFF
--- a/src/tenable/TenableClient.test.ts
+++ b/src/tenable/TenableClient.test.ts
@@ -145,6 +145,18 @@ describe("TenableClient fetch errors", () => {
     scope.done();
   });
 
+  test("fetchScanHostVulnerabilities unknown error", async () => {
+    const scope = nock(`https://${TENABLE_COM}`)
+      .get("/scans/6/hosts/2")
+      .times(RETRY_MAX_ATTEMPTS - 1)
+      .reply(500);
+    const client = getClient();
+    await expect(client.fetchScanHostVulnerabilities(6, 2)).rejects.toThrow(
+      /500/,
+    );
+    scope.done();
+  });
+
   test("fetchScanDetail unknown error", async () => {
     const scope = nock(`https://${TENABLE_COM}`)
       .get(
@@ -260,6 +272,16 @@ describe("TenableClient data fetch", () => {
 
     const vulnerabilities = await client.fetchScanHostVulnerabilities(6, 2);
     expect(vulnerabilities.length).not.toEqual(0);
+    nockDone();
+  });
+
+  test("fetchScanHostVulnerabilities 404", async () => {
+    const { nockDone } = await nock.back("vulnerabilities-not-found.json", {
+      before: prepareScope,
+    });
+
+    const vulnerabilities = await client.fetchScanHostVulnerabilities(19, 2000);
+    expect(vulnerabilities.length).toEqual(0);
     nockDone();
   });
 

--- a/src/tenable/createAssetExportCache.ts
+++ b/src/tenable/createAssetExportCache.ts
@@ -36,7 +36,7 @@ async function getAssetExports(client: TenableClient) {
     chunks_available: chunksAvailable,
   } = await client.fetchAssetsExportStatus(exportUuid);
 
-  const timeLimit = addMinutes(Date.now(), 10);
+  const timeLimit = addMinutes(Date.now(), 20);
   while ([ExportStatus.Processing, ExportStatus.Queued].includes(status)) {
     ({
       status,

--- a/src/tenable/createVulnerabilityExportCache.ts
+++ b/src/tenable/createVulnerabilityExportCache.ts
@@ -88,7 +88,7 @@ async function getVulnerabilityExports(client: TenableClient) {
     chunks_available: chunksAvailable,
   } = await client.fetchVulnerabilitiesExportStatus(exportUuid);
 
-  const timeLimit = addMinutes(Date.now(), 10);
+  const timeLimit = addMinutes(Date.now(), 20);
   while ([ExportStatus.Processing, ExportStatus.Queued].includes(status)) {
     if (isAfter(Date.now(), timeLimit)) {
       throw new IntegrationError({

--- a/test/fixtures/vulnerabilities-not-found.json
+++ b/test/fixtures/vulnerabilities-not-found.json
@@ -1,0 +1,40 @@
+[
+  {
+    "scope": "https://cloud.tenable.com:443",
+    "method": "GET",
+    "path": "/scans/19/hosts/2000",
+    "body": "",
+    "status": 404,
+    "response": {
+      "error": "No asset found for id 2000"
+    },
+    "rawHeaders": [
+      "Date",
+      "Mon, 17 May 2021 18:34:34 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "38",
+      "Connection",
+      "close",
+      "Set-Cookie",
+      "nginx-cloud-site-id=us-3a; path=/; HttpOnly; SameSite=Strict; Secure",
+      "Set-Cookie",
+      "nginx-cloud-site-id=us-3a; path=/; HttpOnly; SameSite=Strict; Secure",
+      "Cache-Control",
+      "no-cache",
+      "Vary",
+      "accept-encoding",
+      "X-Request-Uuid",
+      "84c88c5de13860c52dbe45e52b89acf9",
+      "X-XSS-Protection",
+      "1; mode=block",
+      "Strict-Transport-Security",
+      "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Gateway-Site-ID",
+      "nginx-router-j0vwe-us-east-2-prod"
+    ]
+  }
+]


### PR DESCRIPTION
It was reported that a customer was seeing a 404 in their integration job log. Investigating revealed that the Tenable API was returning 404s for `https://cloud.tenable.com/scans/scan_uuid/hosts/host_id` which is most likely because the hosts are older than 35 days. This should allow for job executions to complete until work is done to finish migrating the scan details endpoint to the export api and allow for ingestion of older data.