### PR TITLE
Increase export timeout and sleep between calls to export status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Increase timeout for asset/vuln export
+- Wait between status calls to asset/vuln export
+
 ## 6.0.1 - 2021-05-17
 
 ### Fixed

--- a/src/executionHandler.test.ts
+++ b/src/executionHandler.test.ts
@@ -1,6 +1,6 @@
-import nock from "nock";
-
 import { createTestIntegrationExecutionContext } from "@jupiterone/jupiter-managed-integration-sdk";
+import * as attempt from "@lifeomic/attempt";
+import nock from "nock";
 
 import executionHandler from "./executionHandler";
 import * as Entities from "./jupiterone/entities";
@@ -22,6 +22,12 @@ describe("executionHandler", () => {
     process.env.CI
       ? nock.back.setMode("lockdown")
       : nock.back.setMode("record");
+    jest.spyOn(attempt, "sleep").mockImplementation(
+      () =>
+        new Promise(resolve => {
+          setTimeout(resolve, 0);
+        }),
+    );
   });
 
   test("INGEST action with no data", async () => {

--- a/src/tenable/createAssetExportCache.ts
+++ b/src/tenable/createAssetExportCache.ts
@@ -6,6 +6,7 @@ import {
   IntegrationError,
   IntegrationLogger,
 } from "@jupiterone/jupiter-managed-integration-sdk";
+import { sleep } from "@lifeomic/attempt";
 import { addMinutes, isAfter } from "date-fns";
 import pMap from "p-map";
 
@@ -36,7 +37,7 @@ async function getAssetExports(client: TenableClient) {
     chunks_available: chunksAvailable,
   } = await client.fetchAssetsExportStatus(exportUuid);
 
-  const timeLimit = addMinutes(Date.now(), 20);
+  const timeLimit = addMinutes(Date.now(), 30);
   while ([ExportStatus.Processing, ExportStatus.Queued].includes(status)) {
     ({
       status,
@@ -49,6 +50,7 @@ async function getAssetExports(client: TenableClient) {
         message: `Asset export ${exportUuid} failed to finish processing in time limit`,
       });
     }
+    await sleep(60_000); // Sleep 1 minute between status checks.
   }
 
   const chunkResponses = await pMap(

--- a/src/tenable/createVulnerabilityExportCache.ts
+++ b/src/tenable/createVulnerabilityExportCache.ts
@@ -12,6 +12,7 @@ import {
   IntegrationError,
   IntegrationLogger,
 } from "@jupiterone/jupiter-managed-integration-sdk";
+import { sleep } from "@lifeomic/attempt";
 import pMap from "p-map";
 
 export async function createVulnerabilityExportCache(
@@ -88,7 +89,7 @@ async function getVulnerabilityExports(client: TenableClient) {
     chunks_available: chunksAvailable,
   } = await client.fetchVulnerabilitiesExportStatus(exportUuid);
 
-  const timeLimit = addMinutes(Date.now(), 20);
+  const timeLimit = addMinutes(Date.now(), 30);
   while ([ExportStatus.Processing, ExportStatus.Queued].includes(status)) {
     if (isAfter(Date.now(), timeLimit)) {
       throw new IntegrationError({
@@ -101,6 +102,7 @@ async function getVulnerabilityExports(client: TenableClient) {
       status,
       chunks_available: chunksAvailable,
     } = await client.fetchVulnerabilitiesExportStatus(exportUuid));
+    await sleep(60_000); // Sleep 1 minute between status checks.
   }
 
   const chunkResponses = await pMap(

--- a/src/tenable/index.test.ts
+++ b/src/tenable/index.test.ts
@@ -2,6 +2,7 @@ import {
   IntegrationError,
   IntegrationLogger,
 } from "@jupiterone/jupiter-managed-integration-sdk";
+import * as attempt from "@lifeomic/attempt";
 import { subMinutes } from "date-fns";
 import nock from "nock";
 import { createAssetExportCache } from "./createAssetExportCache";
@@ -49,6 +50,12 @@ describe("AssetExportCache", () => {
     process.env.CI
       ? nock.back.setMode("lockdown")
       : nock.back.setMode("record");
+    jest.spyOn(attempt, "sleep").mockImplementation(
+      () =>
+        new Promise(resolve => {
+          setTimeout(resolve, 0);
+        }),
+    );
   });
 
   beforeEach(() => {
@@ -69,7 +76,7 @@ describe("AssetExportCache", () => {
     const { nockDone } = await nock.back("export-assets-full-cycle.json", {
       before: prepareScope,
     });
-    const timeout = subMinutes(Date.now(), 30).valueOf();
+    const timeout = subMinutes(Date.now(), 40).valueOf();
     jest.spyOn(global.Date, "now").mockImplementationOnce(() => timeout);
 
     try {
@@ -119,6 +126,12 @@ describe("VulnerabilityExportCache", () => {
     process.env.CI
       ? nock.back.setMode("lockdown")
       : nock.back.setMode("record");
+    jest.spyOn(attempt, "sleep").mockImplementation(
+      () =>
+        new Promise(resolve => {
+          setTimeout(resolve, 0);
+        }),
+    );
   });
 
   beforeEach(() => {
@@ -151,7 +164,7 @@ describe("VulnerabilityExportCache", () => {
     );
     jest.clearAllMocks();
 
-    const timeout = subMinutes(Date.now(), 30).valueOf();
+    const timeout = subMinutes(Date.now(), 40).valueOf();
     jest
       .spyOn(global.Date, "now")
       .mockImplementationOnce(() => new Date("2020-01-01").valueOf())


### PR DESCRIPTION
Increase timeout for larger exports and give the status endpoint some breathing room (429 errors)