### PR TITLE
Log asset export status response

### DIFF
--- a/src/tenable/createAssetExportCache.ts
+++ b/src/tenable/createAssetExportCache.ts
@@ -14,7 +14,7 @@ export async function createAssetExportCache(
   logger: IntegrationLogger,
   client: TenableClient,
 ): Promise<AssetExportCache> {
-  const assetExports = await getAssetExports(client);
+  const assetExports = await getAssetsUsingExport(client);
   const assetExportMap = new Map<string, AssetExport>();
 
   logger.info({ assetExports: assetExports.length }, "Fetched asset exports");
@@ -29,7 +29,7 @@ export async function createAssetExportCache(
   };
 }
 
-async function getAssetExports(client: TenableClient) {
+async function getAssetsUsingExport(client: TenableClient) {
   const options: ExportAssetsOptions = { chunk_size: 100 };
   const { export_uuid: exportUuid } = await client.exportAssets(options);
   let {

--- a/src/tenable/types.ts
+++ b/src/tenable/types.ts
@@ -697,6 +697,19 @@ export interface AssetsExportStatusResponse {
   chunks_available: number[];
 }
 
+interface AssetExportJob {
+  uuid: string;
+  total_chunks: number;
+  filters: any;
+  finished_chunks: number;
+  num_assets_per_chunk: number;
+  created: number;
+}
+
+export interface AssetExportJobsResponse {
+  exports: AssetExportJob;
+}
+
 export interface AssetExport {
   id: string;
   has_agent: boolean;


### PR DESCRIPTION
I don't know of an interface we can use to expose these asset export job IDs to the customer. 