### PR TITLE
Add client.iterateAssets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Added
 
-- Added `TenableClient.iteraetAssets()` method. Made other asset export
+- Added `TenableClient.iterateAssets()` method. Made other asset export
   endpoints private.
 
 ## 7.1.4 - 2021-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added `TenableClient.iteraetAssets()` method. Made other asset export
+  endpoints private.
+
 ## 7.1.4 - 2021-07-13
 
 ### Fixed

--- a/src/tenable/TenableClient.test.ts
+++ b/src/tenable/TenableClient.test.ts
@@ -10,7 +10,7 @@ import {
 
 import TenableClient from './TenableClient';
 import {
-  ExportAssetsOptions,
+  AssetExport,
   ExportVulnerabilitiesOptions,
   RecentScanDetail,
   RecentScanSummary,
@@ -404,44 +404,6 @@ describe.skip('TenableClient data fetch', () => {
     nockDone();
   });
 
-  test('exportAssets ok', async () => {
-    const { nockDone } = await nock.back('export-assets-ok.json', {
-      before: prepareScope,
-    });
-
-    const options: ExportAssetsOptions = {
-      chunk_size: 100,
-    };
-    const response = await client.exportAssets(options);
-    expect(response).not.toEqual({});
-    nockDone();
-  });
-
-  test('fetchAssetsExportStatus ok', async () => {
-    const { nockDone } = await nock.back('assets-export-status-ok.json', {
-      before: prepareScope,
-    });
-
-    const response = await client.fetchAssetsExportStatus(
-      '5dc52d4e-82d1-4988-8231-98dbe6ce62cd',
-    );
-    expect(response).not.toEqual({});
-    nockDone();
-  });
-
-  test('fetchAssetsExportChunk ok', async () => {
-    const { nockDone } = await nock.back('assets-export-chunk-ok.json', {
-      before: prepareScope,
-    });
-
-    const response = await client.fetchAssetsExportChunk(
-      '5dc52d4e-82d1-4988-8231-98dbe6ce62cd',
-      1,
-    );
-    expect(response.length).not.toEqual(0);
-    nockDone();
-  });
-
   test.skip('fetchTenableData ok', async () => {
     const { nockDone } = await nock.back('all-data-ok.json', {
       before: prepareScope,
@@ -462,11 +424,11 @@ describe.skip('TenableClient data fetch', () => {
   });
 });
 
-describe('cancelAssetExport', () => {
-  test('success', async () => {
+describe('iterateAssets', () => {
+  test('should iterate all assets', async () => {
     recording = setupTenableRecording({
       directory: __dirname,
-      name: 'cancelAssetExport',
+      name: 'iterateAssets-success',
       options: {
         matchRequestsBy: getTenableMatchRequestsBy(config),
       },
@@ -478,10 +440,11 @@ describe('cancelAssetExport', () => {
       secretToken: config.secretKey,
     });
 
-    const { export_uuid } = await client.exportAssets({ chunk_size: 100 });
+    const assets: AssetExport[] = [];
+    await client.iterateAssets((a) => {
+      assets.push(a);
+    });
 
-    const response = await client.cancelAssetExport(export_uuid);
-
-    expect(response.response.status).toBe('CANCELLED');
-  });
+    expect(assets.length).toBeGreaterThan(0);
+  }, 10_000);
 });

--- a/src/tenable/TenableClient.test.ts
+++ b/src/tenable/TenableClient.test.ts
@@ -424,6 +424,10 @@ describe.skip('TenableClient data fetch', () => {
   });
 });
 
+function flushPromises() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
 describe('iterateAssets', () => {
   test('should iterate all assets', async () => {
     recording = setupTenableRecording({
@@ -440,11 +444,17 @@ describe('iterateAssets', () => {
       secretToken: config.secretKey,
     });
 
+    jest.useFakeTimers();
     const assets: AssetExport[] = [];
-    await client.iterateAssets((a) => {
-      assets.push(a);
-    });
+    client
+      .iterateAssets((a) => {
+        assets.push(a);
+      })
+      .then(() => expect(assets.length).toBeGreaterThan(0))
+      .catch((e) => e);
 
-    expect(assets.length).toBeGreaterThan(0);
-  }, 10_000);
+    jest.runAllTimers();
+    await flushPromises();
+    jest.useRealTimers();
+  });
 });

--- a/src/tenable/TenableClient.ts
+++ b/src/tenable/TenableClient.ts
@@ -346,7 +346,7 @@ export default class TenableClient {
 
       ({ status, chunks_available: chunksAvailable } =
         await this.fetchAssetsExportStatus(exportUuid));
-      await sleep(5_000); // Sleep 5 seconds between status checks.
+      await sleep(60_000); // Sleep 5 seconds between status checks.
     }
 
     await pMap(

--- a/src/tenable/TenableClient.ts
+++ b/src/tenable/TenableClient.ts
@@ -1,7 +1,11 @@
 import { version as graphTenablePackageVersion } from '../../package.json';
-import Client, { TenableRepsonse } from '@jupiterone/tenable-client-nodejs';
+import Client, {
+  ExportStatus,
+  TenableRepsonse,
+} from '@jupiterone/tenable-client-nodejs';
 
 import {
+  IntegrationError,
   IntegrationLogger,
   IntegrationProviderAPIError,
 } from '@jupiterone/integration-sdk-core';
@@ -27,6 +31,10 @@ import {
   VulnerabilitiesExportStatusResponse,
   VulnerabilityExport,
 } from '@jupiterone/tenable-client-nodejs';
+import isAfter from 'date-fns/isAfter';
+import { sleep } from '@lifeomic/attempt';
+import pMap from 'p-map';
+import addMinutes from 'date-fns/addMinutes';
 
 function length(resources?: any[]): number {
   return resources ? resources.length : 0;
@@ -238,7 +246,7 @@ export default class TenableClient {
     return vulnerabilitiesExportResponse;
   }
 
-  public async exportAssets(
+  private async exportAssets(
     options: ExportAssetsOptions,
   ): Promise<ExportAssetsResponse> {
     const exportResponse = await this.retryRequest(() =>
@@ -256,7 +264,7 @@ export default class TenableClient {
     return exportResponse;
   }
 
-  public async cancelAssetExport(
+  private async cancelAssetExport(
     exportUuid: string,
   ): Promise<CancelExportResponse> {
     const cancelExportResponse = await this.retryRequest(() =>
@@ -273,7 +281,7 @@ export default class TenableClient {
     return cancelExportResponse;
   }
 
-  public async fetchAssetsExportStatus(
+  private async fetchAssetsExportStatus(
     exportUuid: string,
   ): Promise<AssetsExportStatusResponse> {
     const exportStatusResponse = await this.retryRequest(() =>
@@ -291,7 +299,7 @@ export default class TenableClient {
     return exportStatusResponse;
   }
 
-  public async fetchAssetsExportChunk(
+  private async fetchAssetsExportChunk(
     exportUuid: string,
     chunkId: number,
   ): Promise<AssetExport[]> {
@@ -309,6 +317,49 @@ export default class TenableClient {
     );
 
     return assetsExportResponse;
+  }
+
+  public async iterateAssets(
+    callback: (asset: AssetExport) => void | Promise<void>,
+    options?: {
+      timeoutInMinutes?: number;
+      chunkSize?: number;
+    },
+  ) {
+    const chunkSize = options?.chunkSize || 100;
+    const timeoutInMinutes = options?.timeoutInMinutes || 30;
+    const { export_uuid: exportUuid } = await this.exportAssets({
+      chunk_size: chunkSize,
+    });
+    let { status, chunks_available: chunksAvailable } =
+      await this.fetchAssetsExportStatus(exportUuid);
+
+    const timeLimit = addMinutes(Date.now(), timeoutInMinutes);
+    while ([ExportStatus.Processing, ExportStatus.Queued].includes(status)) {
+      if (isAfter(Date.now(), timeLimit)) {
+        await this.cancelAssetExport(exportUuid);
+        throw new IntegrationError({
+          code: 'TenableClientApiError',
+          message: `Asset export ${exportUuid} failed to finish processing in time limit`,
+        });
+      }
+
+      ({ status, chunks_available: chunksAvailable } =
+        await this.fetchAssetsExportStatus(exportUuid));
+      await sleep(5_000); // Sleep 5 seconds between status checks.
+    }
+
+    await pMap(
+      chunksAvailable,
+      async (chunkId) => {
+        const assets = await this.fetchAssetsExportChunk(exportUuid, chunkId);
+        for (const asset of assets) {
+          await callback(asset);
+        }
+      },
+      { concurrency: 3 },
+    );
+    return { exportUuid };
   }
 
   public async fetchScanHostVulnerabilities(

--- a/src/tenable/__recordings__/iterateAssets-success_1289501922/recording.har
+++ b/src/tenable/__recordings__/iterateAssets-success_1289501922/recording.har
@@ -1,0 +1,672 @@
+{
+  "log": {
+    "_recordingName": "iterateAssets-success",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "13f407143817c1078c52730416aef925",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 18,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "identity"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-apikeys",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "Integration/1.0 (JupiterOne; graph-tenable-cloud; Build/7.1.4) @jupiterone/tenable-client-nodejs/0.1.2 (@jupiterone/tenable-client-nodejs/0.1.2; Node.js/v12.21.0; darwin/20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "18"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "cloud.tenable.com"
+            }
+          ],
+          "headersSize": 561,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"chunk_size\":100}"
+          },
+          "queryString": [],
+          "url": "https://cloud.tenable.com/assets/export"
+        },
+        "response": {
+          "bodySize": 54,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 54,
+            "text": "{\"export_uuid\":\"478bbebf-418e-4da1-b78f-559aa1a119f5\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "nginx-cloud-site-id",
+              "path": "/",
+              "sameSite": "Strict",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "nginx-cloud-site-id",
+              "path": "/",
+              "sameSite": "Strict",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 19 Jul 2021 13:53:54 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "54"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "x-request-uuid",
+              "value": "19fcc88c00160d8b4c0e9bc3fb1dc8c3"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "vary",
+              "value": "accept-encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=63072000; includeSubDomains"
+            },
+            {
+              "name": "x-gateway-site-id",
+              "value": "nginx-router-om1qv-us-east-1-prod"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expect-ct",
+              "value": "enforce, max-age=86400"
+            }
+          ],
+          "headersSize": 646,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-19T13:53:54.531Z",
+        "time": 411,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 411
+        }
+      },
+      {
+        "_id": "cd27d4c3908d56b56f7205d0a9c562ca",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "identity"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-apikeys",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "Integration/1.0 (JupiterOne; graph-tenable-cloud; Build/7.1.4) @jupiterone/tenable-client-nodejs/0.1.2 (@jupiterone/tenable-client-nodejs/0.1.2; Node.js/v12.21.0; darwin/20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "cloud.tenable.com"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://cloud.tenable.com/assets/export/478bbebf-418e-4da1-b78f-559aa1a119f5/status"
+        },
+        "response": {
+          "bodySize": 45,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 45,
+            "text": "{\"status\":\"PROCESSING\",\"chunks_available\":[]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "nginx-cloud-site-id",
+              "path": "/",
+              "sameSite": "Strict",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "nginx-cloud-site-id",
+              "path": "/",
+              "sameSite": "Strict",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 19 Jul 2021 13:53:55 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "45"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "x-request-uuid",
+              "value": "1952423cd95101cd37a202e725d1f1cd"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "vary",
+              "value": "accept-encoding"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=63072000; includeSubDomains"
+            },
+            {
+              "name": "x-gateway-site-id",
+              "value": "nginx-router-qswjo-us-east-1-prod"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expect-ct",
+              "value": "enforce, max-age=86400"
+            }
+          ],
+          "headersSize": 668,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-19T13:53:54.948Z",
+        "time": 585,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 585
+        }
+      },
+      {
+        "_id": "cd27d4c3908d56b56f7205d0a9c562ca",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "identity"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-apikeys",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "Integration/1.0 (JupiterOne; graph-tenable-cloud; Build/7.1.4) @jupiterone/tenable-client-nodejs/0.1.2 (@jupiterone/tenable-client-nodejs/0.1.2; Node.js/v12.21.0; darwin/20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "cloud.tenable.com"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://cloud.tenable.com/assets/export/478bbebf-418e-4da1-b78f-559aa1a119f5/status"
+        },
+        "response": {
+          "bodySize": 44,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 44,
+            "text": "{\"status\":\"FINISHED\",\"chunks_available\":[1]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "nginx-cloud-site-id",
+              "path": "/",
+              "sameSite": "Strict",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "nginx-cloud-site-id",
+              "path": "/",
+              "sameSite": "Strict",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 19 Jul 2021 13:53:55 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "44"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "x-request-uuid",
+              "value": "c89d45525928590641e7374653333df8"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "vary",
+              "value": "accept-encoding"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=63072000; includeSubDomains"
+            },
+            {
+              "name": "x-gateway-site-id",
+              "value": "nginx-router-tij7y-us-east-1-prod"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expect-ct",
+              "value": "enforce, max-age=86400"
+            }
+          ],
+          "headersSize": 668,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-19T13:53:55.536Z",
+        "time": 394,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 394
+        }
+      },
+      {
+        "_id": "983d7a0b0a2ee10467a1279d5e0c6c32",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "identity"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-apikeys",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "Integration/1.0 (JupiterOne; graph-tenable-cloud; Build/7.1.4) @jupiterone/tenable-client-nodejs/0.1.2 (@jupiterone/tenable-client-nodejs/0.1.2; Node.js/v12.21.0; darwin/20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "cloud.tenable.com"
+            }
+          ],
+          "headersSize": 586,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://cloud.tenable.com/assets/export/478bbebf-418e-4da1-b78f-559aa1a119f5/chunks/1"
+        },
+        "response": {
+          "bodySize": 18248,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 18248,
+            "text": "[{\"id\":\"c018734a-1892-4ecc-b732-dbb54f2ddbd5\",\"has_agent\":false,\"has_plugin_results\":null,\"created_at\":\"2021-06-16T19:24:52.274Z\",\"terminated_at\":\"2021-06-21T17:32:18.911Z\",\"terminated_by\":\"AZURE\",\"updated_at\":\"2021-06-22T14:05:48.669Z\",\"deleted_at\":null,\"deleted_by\":null,\"first_seen\":\"2021-06-16T19:24:51.970Z\",\"last_seen\":\"2021-06-16T19:24:51.970Z\",\"first_scan_time\":null,\"last_scan_time\":null,\"last_authenticated_scan_date\":null,\"last_licensed_scan_date\":null,\"last_scan_id\":null,\"last_schedule_id\":null,\"azure_vm_id\":\"b21753a7-5453-4aed-b638-9458be1c8749\",\"azure_resource_id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.compute/virtualmachines/rfp-linux\",\"gcp_project_id\":null,\"gcp_zone\":null,\"gcp_instance_id\":null,\"aws_ec2_instance_ami_id\":null,\"aws_ec2_instance_id\":null,\"agent_uuid\":null,\"bios_uuid\":null,\"network_id\":\"00000000-0000-0000-0000-000000000000\",\"network_name\":\"Default\",\"aws_owner_id\":null,\"aws_availability_zone\":null,\"aws_region\":null,\"aws_vpc_id\":null,\"aws_ec2_instance_group_name\":null,\"aws_ec2_instance_state_name\":null,\"aws_ec2_instance_type\":null,\"aws_subnet_id\":null,\"aws_ec2_product_code\":null,\"aws_ec2_name\":null,\"mcafee_epo_guid\":null,\"mcafee_epo_agent_guid\":null,\"servicenow_sysid\":null,\"bigfix_asset_id\":null,\"agent_names\":[],\"installed_software\":[],\"ipv4s\":[\"10.0.2.9\"],\"ipv6s\":[],\"fqdns\":[],\"mac_addresses\":[],\"netbios_names\":[],\"operating_systems\":[\"Linux\"],\"system_types\":[\"azure-instance\"],\"hostnames\":[\"rfp-linux\"],\"ssh_fingerprints\":[],\"qualys_asset_ids\":[],\"qualys_host_ids\":[],\"manufacturer_tpm_ids\":[],\"symantec_ep_hardware_keys\":[],\"sources\":[{\"name\":\"AZURE\",\"first_seen\":\"2021-06-16T19:24:51.970Z\",\"last_seen\":\"2021-06-16T19:24:51.970Z\"}],\"tags\":[],\"network_interfaces\":[{\"name\":\"UNKNOWN\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[],\"ipv4s\":[\"10.0.2.9\"],\"ipv6s\":[]}]},{\"id\":\"5306092a-8902-4d12-817d-405492e04bb8\",\"has_agent\":false,\"has_plugin_results\":null,\"created_at\":\"2021-06-16T19:24:52.268Z\",\"terminated_at\":\"2021-06-21T17:32:18.907Z\",\"terminated_by\":\"AZURE\",\"updated_at\":\"2021-06-22T14:05:48.105Z\",\"deleted_at\":null,\"deleted_by\":null,\"first_seen\":\"2021-06-16T19:24:51.970Z\",\"last_seen\":\"2021-06-16T19:24:51.970Z\",\"first_scan_time\":null,\"last_scan_time\":null,\"last_authenticated_scan_date\":null,\"last_licensed_scan_date\":null,\"last_scan_id\":null,\"last_schedule_id\":null,\"azure_vm_id\":\"f3ba7005-90c5-403b-81d2-8ce04d679bc3\",\"azure_resource_id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.compute/virtualmachines/machine-from-image\",\"gcp_project_id\":null,\"gcp_zone\":null,\"gcp_instance_id\":null,\"aws_ec2_instance_ami_id\":null,\"aws_ec2_instance_id\":null,\"agent_uuid\":null,\"bios_uuid\":null,\"network_id\":\"00000000-0000-0000-0000-000000000000\",\"network_name\":\"Default\",\"aws_owner_id\":null,\"aws_availability_zone\":null,\"aws_region\":null,\"aws_vpc_id\":null,\"aws_ec2_instance_group_name\":null,\"aws_ec2_instance_state_name\":null,\"aws_ec2_instance_type\":null,\"aws_subnet_id\":null,\"aws_ec2_product_code\":null,\"aws_ec2_name\":null,\"mcafee_epo_guid\":null,\"mcafee_epo_agent_guid\":null,\"servicenow_sysid\":null,\"bigfix_asset_id\":null,\"agent_names\":[],\"installed_software\":[],\"ipv4s\":[\"10.0.2.10\"],\"ipv6s\":[],\"fqdns\":[],\"mac_addresses\":[],\"netbios_names\":[],\"operating_systems\":[\"Linux\"],\"system_types\":[\"azure-instance\"],\"hostnames\":[\"machine-from-image\"],\"ssh_fingerprints\":[],\"qualys_asset_ids\":[],\"qualys_host_ids\":[],\"manufacturer_tpm_ids\":[],\"symantec_ep_hardware_keys\":[],\"sources\":[{\"name\":\"AZURE\",\"first_seen\":\"2021-06-16T19:24:51.970Z\",\"last_seen\":\"2021-06-16T19:24:51.970Z\"}],\"tags\":[],\"network_interfaces\":[{\"name\":\"UNKNOWN\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[],\"ipv4s\":[\"10.0.2.10\"],\"ipv6s\":[]}]},{\"id\":\"04605b0d-c85e-4539-b130-80b75a618c97\",\"has_agent\":false,\"has_plugin_results\":null,\"created_at\":\"2021-06-16T19:24:52.268Z\",\"terminated_at\":\"2021-06-21T17:32:18.909Z\",\"terminated_by\":\"AZURE\",\"updated_at\":\"2021-06-22T14:05:48.297Z\",\"deleted_at\":null,\"deleted_by\":null,\"first_seen\":\"2021-06-16T19:24:51.970Z\",\"last_seen\":\"2021-06-16T19:24:51.970Z\",\"first_scan_time\":null,\"last_scan_time\":null,\"last_authenticated_scan_date\":null,\"last_licensed_scan_date\":null,\"last_scan_id\":null,\"last_schedule_id\":null,\"azure_vm_id\":\"a9c23301-e114-4920-aaf8-abb54a1e8759\",\"azure_resource_id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.compute/virtualmachines/machine-from-gallery\",\"gcp_project_id\":null,\"gcp_zone\":null,\"gcp_instance_id\":null,\"aws_ec2_instance_ami_id\":null,\"aws_ec2_instance_id\":null,\"agent_uuid\":null,\"bios_uuid\":null,\"network_id\":\"00000000-0000-0000-0000-000000000000\",\"network_name\":\"Default\",\"aws_owner_id\":null,\"aws_availability_zone\":null,\"aws_region\":null,\"aws_vpc_id\":null,\"aws_ec2_instance_group_name\":null,\"aws_ec2_instance_state_name\":null,\"aws_ec2_instance_type\":null,\"aws_subnet_id\":null,\"aws_ec2_product_code\":null,\"aws_ec2_name\":null,\"mcafee_epo_guid\":null,\"mcafee_epo_agent_guid\":null,\"servicenow_sysid\":null,\"bigfix_asset_id\":null,\"agent_names\":[],\"installed_software\":[],\"ipv4s\":[\"10.0.2.11\"],\"ipv6s\":[],\"fqdns\":[],\"mac_addresses\":[],\"netbios_names\":[],\"operating_systems\":[\"Linux\"],\"system_types\":[\"azure-instance\"],\"hostnames\":[\"machine-from-gallery\"],\"ssh_fingerprints\":[],\"qualys_asset_ids\":[],\"qualys_host_ids\":[],\"manufacturer_tpm_ids\":[],\"symantec_ep_hardware_keys\":[],\"sources\":[{\"name\":\"AZURE\",\"first_seen\":\"2021-06-16T19:24:51.970Z\",\"last_seen\":\"2021-06-16T19:24:51.970Z\"}],\"tags\":[],\"network_interfaces\":[{\"name\":\"UNKNOWN\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[],\"ipv4s\":[\"10.0.2.11\"],\"ipv6s\":[]}]},{\"id\":\"4c100f7d-ee60-4de0-8a7a-68b8ac399a86\",\"has_agent\":false,\"has_plugin_results\":null,\"created_at\":\"2021-06-16T19:24:52.266Z\",\"terminated_at\":\"2021-06-21T17:32:18.923Z\",\"terminated_by\":\"AZURE\",\"updated_at\":\"2021-06-22T14:05:47.565Z\",\"deleted_at\":null,\"deleted_by\":null,\"first_seen\":\"2021-06-16T19:24:51.971Z\",\"last_seen\":\"2021-06-16T19:24:51.971Z\",\"first_scan_time\":null,\"last_scan_time\":null,\"last_authenticated_scan_date\":null,\"last_licensed_scan_date\":null,\"last_scan_id\":null,\"last_schedule_id\":null,\"azure_vm_id\":\"689c2737-fd85-4cb7-8026-4f8ea2d9157f\",\"azure_resource_id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.compute/virtualmachines/ubuntu\",\"gcp_project_id\":null,\"gcp_zone\":null,\"gcp_instance_id\":null,\"aws_ec2_instance_ami_id\":null,\"aws_ec2_instance_id\":null,\"agent_uuid\":null,\"bios_uuid\":null,\"network_id\":\"00000000-0000-0000-0000-000000000000\",\"network_name\":\"Default\",\"aws_owner_id\":null,\"aws_availability_zone\":null,\"aws_region\":null,\"aws_vpc_id\":null,\"aws_ec2_instance_group_name\":null,\"aws_ec2_instance_state_name\":null,\"aws_ec2_instance_type\":null,\"aws_subnet_id\":null,\"aws_ec2_product_code\":null,\"aws_ec2_name\":null,\"mcafee_epo_guid\":null,\"mcafee_epo_agent_guid\":null,\"servicenow_sysid\":null,\"bigfix_asset_id\":null,\"agent_names\":[],\"installed_software\":[],\"ipv4s\":[\"10.0.2.15\",\"40.114.74.217\"],\"ipv6s\":[],\"fqdns\":[],\"mac_addresses\":[],\"netbios_names\":[],\"operating_systems\":[\"Linux\"],\"system_types\":[\"azure-instance\"],\"hostnames\":[\"ubuntu\"],\"ssh_fingerprints\":[],\"qualys_asset_ids\":[],\"qualys_host_ids\":[],\"manufacturer_tpm_ids\":[],\"symantec_ep_hardware_keys\":[],\"sources\":[{\"name\":\"AZURE\",\"first_seen\":\"2021-06-16T19:24:51.971Z\",\"last_seen\":\"2021-06-16T19:24:51.971Z\"}],\"tags\":[],\"network_interfaces\":[{\"name\":\"UNKNOWN\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[],\"ipv4s\":[\"10.0.2.15\",\"40.114.74.217\"],\"ipv6s\":[]}]},{\"id\":\"7cef16fd-c698-4ad5-a20b-67d8c3bedd7d\",\"has_agent\":false,\"has_plugin_results\":null,\"created_at\":\"2021-06-16T19:24:52.265Z\",\"terminated_at\":\"2021-06-21T17:32:18.907Z\",\"terminated_by\":\"AZURE\",\"updated_at\":\"2021-06-22T14:05:47.937Z\",\"deleted_at\":null,\"deleted_by\":null,\"first_seen\":\"2021-06-16T19:24:51.969Z\",\"last_seen\":\"2021-06-16T19:24:51.969Z\",\"first_scan_time\":null,\"last_scan_time\":null,\"last_authenticated_scan_date\":null,\"last_licensed_scan_date\":null,\"last_scan_id\":null,\"last_schedule_id\":null,\"azure_vm_id\":\"aa6fc622-a46f-4a54-9a81-2f11babbb3d0\",\"azure_resource_id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.compute/virtualmachines/2021-06-10-test\",\"gcp_project_id\":null,\"gcp_zone\":null,\"gcp_instance_id\":null,\"aws_ec2_instance_ami_id\":null,\"aws_ec2_instance_id\":null,\"agent_uuid\":null,\"bios_uuid\":null,\"network_id\":\"00000000-0000-0000-0000-000000000000\",\"network_name\":\"Default\",\"aws_owner_id\":null,\"aws_availability_zone\":null,\"aws_region\":null,\"aws_vpc_id\":null,\"aws_ec2_instance_group_name\":null,\"aws_ec2_instance_state_name\":null,\"aws_ec2_instance_type\":null,\"aws_subnet_id\":null,\"aws_ec2_product_code\":null,\"aws_ec2_name\":null,\"mcafee_epo_guid\":null,\"mcafee_epo_agent_guid\":null,\"servicenow_sysid\":null,\"bigfix_asset_id\":null,\"agent_names\":[],\"installed_software\":[],\"ipv4s\":[\"10.0.2.13\",\"52.170.83.26\"],\"ipv6s\":[],\"fqdns\":[],\"mac_addresses\":[],\"netbios_names\":[],\"operating_systems\":[\"Linux\"],\"system_types\":[\"azure-instance\"],\"hostnames\":[\"2021-06-10-test\"],\"ssh_fingerprints\":[],\"qualys_asset_ids\":[],\"qualys_host_ids\":[],\"manufacturer_tpm_ids\":[],\"symantec_ep_hardware_keys\":[],\"sources\":[{\"name\":\"AZURE\",\"first_seen\":\"2021-06-16T19:24:51.969Z\",\"last_seen\":\"2021-06-16T19:24:51.969Z\"}],\"tags\":[],\"network_interfaces\":[{\"name\":\"UNKNOWN\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[],\"ipv4s\":[\"10.0.2.13\",\"52.170.83.26\"],\"ipv6s\":[]}]},{\"id\":\"7a9d9e79-b137-48a9-b7f9-1b0e1a7df5e8\",\"has_agent\":false,\"has_plugin_results\":null,\"created_at\":\"2021-06-16T19:24:52.271Z\",\"terminated_at\":\"2021-06-21T17:32:18.926Z\",\"terminated_by\":\"AZURE\",\"updated_at\":\"2021-06-22T14:05:48.862Z\",\"deleted_at\":null,\"deleted_by\":null,\"first_seen\":\"2021-06-16T19:24:51.971Z\",\"last_seen\":\"2021-06-16T19:24:51.971Z\",\"first_scan_time\":null,\"last_scan_time\":null,\"last_authenticated_scan_date\":null,\"last_licensed_scan_date\":null,\"last_scan_id\":null,\"last_schedule_id\":null,\"azure_vm_id\":\"3402d790-8d05-4d8a-981d-9df022963da5\",\"azure_resource_id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.compute/virtualmachines/service-managed-identity\",\"gcp_project_id\":null,\"gcp_zone\":null,\"gcp_instance_id\":null,\"aws_ec2_instance_ami_id\":null,\"aws_ec2_instance_id\":null,\"agent_uuid\":null,\"bios_uuid\":null,\"network_id\":\"00000000-0000-0000-0000-000000000000\",\"network_name\":\"Default\",\"aws_owner_id\":null,\"aws_availability_zone\":null,\"aws_region\":null,\"aws_vpc_id\":null,\"aws_ec2_instance_group_name\":null,\"aws_ec2_instance_state_name\":null,\"aws_ec2_instance_type\":null,\"aws_subnet_id\":null,\"aws_ec2_product_code\":null,\"aws_ec2_name\":null,\"mcafee_epo_guid\":null,\"mcafee_epo_agent_guid\":null,\"servicenow_sysid\":null,\"bigfix_asset_id\":null,\"agent_names\":[],\"installed_software\":[],\"ipv4s\":[\"10.0.2.12\"],\"ipv6s\":[],\"fqdns\":[],\"mac_addresses\":[],\"netbios_names\":[],\"operating_systems\":[\"Linux\"],\"system_types\":[\"azure-instance\"],\"hostnames\":[\"service-managed-identity\"],\"ssh_fingerprints\":[],\"qualys_asset_ids\":[],\"qualys_host_ids\":[],\"manufacturer_tpm_ids\":[],\"symantec_ep_hardware_keys\":[],\"sources\":[{\"name\":\"AZURE\",\"first_seen\":\"2021-06-16T19:24:51.971Z\",\"last_seen\":\"2021-06-16T19:24:51.971Z\"}],\"tags\":[],\"network_interfaces\":[{\"name\":\"UNKNOWN\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[],\"ipv4s\":[\"10.0.2.12\"],\"ipv6s\":[]}]},{\"id\":\"620b7399-2f1c-4d2e-b370-ea3502b0bc41\",\"has_agent\":false,\"has_plugin_results\":null,\"created_at\":\"2021-06-16T19:24:52.270Z\",\"terminated_at\":\"2021-06-21T17:32:18.905Z\",\"terminated_by\":\"AZURE\",\"updated_at\":\"2021-06-22T14:05:47.753Z\",\"deleted_at\":null,\"deleted_by\":null,\"first_seen\":\"2021-06-16T19:24:51.970Z\",\"last_seen\":\"2021-06-16T19:24:51.970Z\",\"first_scan_time\":null,\"last_scan_time\":null,\"last_authenticated_scan_date\":null,\"last_licensed_scan_date\":null,\"last_scan_id\":null,\"last_schedule_id\":null,\"azure_vm_id\":\"2c363c32-b9ed-4b5f-acf6-0c31c88d22db\",\"azure_resource_id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.compute/virtualmachines/new-machine-from-image\",\"gcp_project_id\":null,\"gcp_zone\":null,\"gcp_instance_id\":null,\"aws_ec2_instance_ami_id\":null,\"aws_ec2_instance_id\":null,\"agent_uuid\":null,\"bios_uuid\":null,\"network_id\":\"00000000-0000-0000-0000-000000000000\",\"network_name\":\"Default\",\"aws_owner_id\":null,\"aws_availability_zone\":null,\"aws_region\":null,\"aws_vpc_id\":null,\"aws_ec2_instance_group_name\":null,\"aws_ec2_instance_state_name\":null,\"aws_ec2_instance_type\":null,\"aws_subnet_id\":null,\"aws_ec2_product_code\":null,\"aws_ec2_name\":null,\"mcafee_epo_guid\":null,\"mcafee_epo_agent_guid\":null,\"servicenow_sysid\":null,\"bigfix_asset_id\":null,\"agent_names\":[],\"installed_software\":[],\"ipv4s\":[\"40.121.38.103\",\"10.0.2.14\"],\"ipv6s\":[],\"fqdns\":[],\"mac_addresses\":[],\"netbios_names\":[],\"operating_systems\":[\"Linux\"],\"system_types\":[\"azure-instance\"],\"hostnames\":[\"new-machine-from-image\"],\"ssh_fingerprints\":[],\"qualys_asset_ids\":[],\"qualys_host_ids\":[],\"manufacturer_tpm_ids\":[],\"symantec_ep_hardware_keys\":[],\"sources\":[{\"name\":\"AZURE\",\"first_seen\":\"2021-06-16T19:24:51.970Z\",\"last_seen\":\"2021-06-16T19:24:51.970Z\"}],\"tags\":[],\"network_interfaces\":[{\"name\":\"UNKNOWN\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[],\"ipv4s\":[\"40.121.38.103\",\"10.0.2.14\"],\"ipv6s\":[]}]},{\"id\":\"604894a3-b8af-4479-85b4-e00343dbd309\",\"has_agent\":true,\"has_plugin_results\":true,\"created_at\":\"2021-05-12T23:48:16.304Z\",\"terminated_at\":null,\"terminated_by\":null,\"updated_at\":\"2021-05-13T00:55:15.218Z\",\"deleted_at\":null,\"deleted_by\":null,\"first_seen\":\"2021-05-12T23:48:13.622Z\",\"last_seen\":\"2021-05-13T00:55:14.227Z\",\"first_scan_time\":\"2021-05-12T23:48:13.622Z\",\"last_scan_time\":\"2021-05-13T00:55:14.227Z\",\"last_authenticated_scan_date\":\"2021-05-13T00:55:14.227Z\",\"last_licensed_scan_date\":\"2021-05-12T23:48:13.622Z\",\"last_scan_id\":\"a4c0b1b7-8e87-41e0-bd62-a284264b1b93\",\"last_schedule_id\":\"template-b9a3940c-9b94-6ca3-19ef-1bbbef6116195e0dedcf141fd667\",\"azure_vm_id\":null,\"azure_resource_id\":null,\"gcp_project_id\":null,\"gcp_zone\":null,\"gcp_instance_id\":null,\"aws_ec2_instance_ami_id\":null,\"aws_ec2_instance_id\":null,\"agent_uuid\":\"094cef57dcda4a71ac1f7df37700f49f\",\"bios_uuid\":\"d4aa7f4f-8c02-4bda-9996-195f3acf85cd\",\"network_id\":\"00000000-0000-0000-0000-000000000000\",\"network_name\":\"Default\",\"aws_owner_id\":null,\"aws_availability_zone\":null,\"aws_region\":null,\"aws_vpc_id\":null,\"aws_ec2_instance_group_name\":null,\"aws_ec2_instance_state_name\":null,\"aws_ec2_instance_type\":null,\"aws_subnet_id\":null,\"aws_ec2_product_code\":null,\"aws_ec2_name\":null,\"mcafee_epo_guid\":null,\"mcafee_epo_agent_guid\":null,\"servicenow_sysid\":null,\"bigfix_asset_id\":null,\"agent_names\":[\"debian-s-1vcpu-1gb-nyc3-01\"],\"installed_software\":[\"cpe:/a:tenable:nessus_agent:8.2.4\"],\"ipv4s\":[\"159.89.38.68\",\"10.17.0.8\",\"10.132.0.4\"],\"ipv6s\":[\"fe80:0:0:0:3425:49ff:fefb:f386\",\"fe80:0:0:0:a4a1:a1ff:fe62:35a6\"],\"fqdns\":[],\"mac_addresses\":[\"36:25:49:fb:f3:86\",\"a6:a1:a1:62:35:a6\"],\"netbios_names\":[],\"operating_systems\":[\"Linux Kernel 4.19.0-10-cloud-amd64 on Debian 10.5\"],\"system_types\":[\"general-purpose\"],\"hostnames\":[\"debian-s-1vcpu-1gb-nyc3-01\"],\"ssh_fingerprints\":[],\"qualys_asset_ids\":[],\"qualys_host_ids\":[],\"manufacturer_tpm_ids\":[],\"symantec_ep_hardware_keys\":[],\"sources\":[{\"name\":\"NESSUS_AGENT\",\"first_seen\":\"2021-05-12T23:48:13.622Z\",\"last_seen\":\"2021-05-13T00:55:14.227Z\"}],\"tags\":[],\"network_interfaces\":[{\"name\":\"lo\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[],\"ipv4s\":[],\"ipv6s\":[]},{\"name\":\"eth0\",\"virtual\":null,\"aliased\":true,\"fqdns\":[],\"mac_addresses\":[\"36:25:49:fb:f3:86\"],\"ipv4s\":[\"159.89.38.68\"],\"ipv6s\":[\"fe80:0:0:0:3425:49ff:fefb:f386\"]},{\"name\":\"eth0:1\",\"virtual\":true,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[\"36:25:49:fb:f3:86\"],\"ipv4s\":[\"10.17.0.8\"],\"ipv6s\":[]},{\"name\":\"eth1\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[\"a6:a1:a1:62:35:a6\"],\"ipv4s\":[\"10.132.0.4\"],\"ipv6s\":[\"fe80:0:0:0:a4a1:a1ff:fe62:35a6\"]},{\"name\":\"UNKNOWN\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[\"a6:a1:a1:62:35:a6\",\"36:25:49:fb:f3:86\"],\"ipv4s\":[\"159.89.38.68\",\"10.17.0.8\",\"10.132.0.4\"],\"ipv6s\":[\"fe80:0:0:0:3425:49ff:fefb:f386\",\"fe80:0:0:0:a4a1:a1ff:fe62:35a6\"]}]},{\"id\":\"48cabb0b-f0fe-4db8-9a96-4fec60e4d4f4\",\"has_agent\":false,\"has_plugin_results\":null,\"created_at\":\"2021-05-12T22:27:09.009Z\",\"terminated_at\":null,\"terminated_by\":null,\"updated_at\":\"2021-05-12T22:27:10.936Z\",\"deleted_at\":null,\"deleted_by\":null,\"first_seen\":\"2021-05-12T22:27:03.798Z\",\"last_seen\":\"2021-05-12T22:27:03.798Z\",\"first_scan_time\":\"2021-05-12T22:27:03.798Z\",\"last_scan_time\":\"2021-05-12T22:27:03.798Z\",\"last_authenticated_scan_date\":null,\"last_licensed_scan_date\":\"2021-05-12T22:27:03.798Z\",\"last_scan_id\":\"92d56999-1a5a-4366-8742-6519013e8d72\",\"last_schedule_id\":\"template-cfdaeaa4-871d-cf00-62cc-b9f5488eb5dfe81ad4dd841d21cb\",\"azure_vm_id\":null,\"azure_resource_id\":null,\"gcp_project_id\":null,\"gcp_zone\":null,\"gcp_instance_id\":null,\"aws_ec2_instance_ami_id\":null,\"aws_ec2_instance_id\":null,\"agent_uuid\":null,\"bios_uuid\":null,\"network_id\":\"00000000-0000-0000-0000-000000000000\",\"network_name\":\"Default\",\"aws_owner_id\":null,\"aws_availability_zone\":null,\"aws_region\":null,\"aws_vpc_id\":null,\"aws_ec2_instance_group_name\":null,\"aws_ec2_instance_state_name\":null,\"aws_ec2_instance_type\":null,\"aws_subnet_id\":null,\"aws_ec2_product_code\":null,\"aws_ec2_name\":null,\"mcafee_epo_guid\":null,\"mcafee_epo_agent_guid\":null,\"servicenow_sysid\":null,\"bigfix_asset_id\":null,\"agent_names\":[],\"installed_software\":[\"cpe:/a:apache:http_server:2.4.29\",\"cpe:/a:apache:http_server:2.4.99\",\"cpe:/a:openbsd:openssh:7.6\"],\"ipv4s\":[\"104.131.67.167\"],\"ipv6s\":[],\"fqdns\":[],\"mac_addresses\":[],\"netbios_names\":[],\"operating_systems\":[\"Linux Kernel 4.15 on Ubuntu 18.04 (bionic)\"],\"system_types\":[\"general-purpose\"],\"hostnames\":[],\"ssh_fingerprints\":[],\"qualys_asset_ids\":[],\"qualys_host_ids\":[],\"manufacturer_tpm_ids\":[],\"symantec_ep_hardware_keys\":[],\"sources\":[{\"name\":\"NESSUS_SCAN\",\"first_seen\":\"2021-05-12T22:27:03.798Z\",\"last_seen\":\"2021-05-12T22:27:03.798Z\"}],\"tags\":[],\"network_interfaces\":[{\"name\":\"UNKNOWN\",\"virtual\":null,\"aliased\":null,\"fqdns\":[],\"mac_addresses\":[],\"ipv4s\":[\"104.131.67.167\"],\"ipv6s\":[]}]}]"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "nginx-cloud-site-id",
+              "path": "/",
+              "sameSite": "Strict",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "nginx-cloud-site-id",
+              "path": "/",
+              "sameSite": "Strict",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 19 Jul 2021 13:54:01 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "vary",
+              "value": "accept-encoding"
+            },
+            {
+              "name": "x-request-uuid",
+              "value": "e765f8ec8c8623903d66f9c08e713a73"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=63072000; includeSubDomains"
+            },
+            {
+              "name": "x-gateway-site-id",
+              "value": "nginx-router-s9c22-us-east-1-prod"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expect-ct",
+              "value": "enforce, max-age=86400"
+            }
+          ],
+          "headersSize": 654,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-19T13:54:00.954Z",
+        "time": 590,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 590
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/tenable/createAssetExportCache.ts
+++ b/src/tenable/createAssetExportCache.ts
@@ -1,18 +1,8 @@
 import { AssetExportCache } from '.';
 import TenableClient from './TenableClient';
-import {
-  AssetExport,
-  ExportAssetsOptions,
-  ExportStatus,
-} from '@jupiterone/tenable-client-nodejs';
+import { AssetExport } from '@jupiterone/tenable-client-nodejs';
 
-import {
-  IntegrationError,
-  IntegrationLogger,
-} from '@jupiterone/integration-sdk-core';
-import { sleep } from '@lifeomic/attempt';
-import { addMinutes, isAfter } from 'date-fns';
-import pMap from 'p-map';
+import { IntegrationLogger } from '@jupiterone/integration-sdk-core';
 
 export async function createAssetExportCache(
   logger: IntegrationLogger,
@@ -34,35 +24,9 @@ export async function createAssetExportCache(
 }
 
 async function getAssetsUsingExport(client: TenableClient) {
-  const options: ExportAssetsOptions = { chunk_size: 100 };
-  const { export_uuid: exportUuid } = await client.exportAssets(options);
-  let { status, chunks_available: chunksAvailable } =
-    await client.fetchAssetsExportStatus(exportUuid);
-
-  const timeLimit = addMinutes(Date.now(), 30);
-  while ([ExportStatus.Processing, ExportStatus.Queued].includes(status)) {
-    ({ status, chunks_available: chunksAvailable } =
-      await client.fetchAssetsExportStatus(exportUuid));
-
-    if (isAfter(Date.now(), timeLimit)) {
-      await client.cancelAssetExport(exportUuid);
-      throw new IntegrationError({
-        code: 'TenableClientApiError',
-        message: `Asset export ${exportUuid} failed to finish processing in time limit`,
-      });
-    }
-    await sleep(60_000); // Sleep 1 minute between status checks.
-  }
-
-  const chunkResponses = await pMap(
-    chunksAvailable,
-    async (chunkId) => await client.fetchAssetsExportChunk(exportUuid, chunkId),
-    { concurrency: 3 },
-  );
-
-  const assetExports = chunkResponses.reduce((prev, cur) => {
-    return prev.concat(cur);
-  }, []);
-
+  const assetExports: AssetExport[] = [];
+  await client.iterateAssets((a) => {
+    assetExports.push(a);
+  });
   return assetExports;
 }


### PR DESCRIPTION
This change sets us up for ingesting `Asset`s as entities, and not having to hold the entire asset cache in memory. The graph is unchanged.

```
### Added

- Added `TenableClient.iteraetAssets()` method. Made other asset export
  endpoints private.
```