### PR TITLE
Remove scan steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@ and this project adheres to
 
 ### Remvoved
 
+- Removed support for ingesting the following entities:
+
+  | Resources             | Entity `_type`                  | Entity `_class`         |
+  | --------------------- | ------------------------------- | ----------------------- |
+  | Scan                  | `tenable_scan`                  | `Assessment`, `Service` |
+  | Vulnerability Finding | `tenable_vulnerability_finding` | `Finding`               |
+
+- Removed support for ingesting the following relationships:
+
+  | Source                          | \_class        | Target                          |
+  | ------------------------------- | -------------- | ------------------------------- |
+  | `tenable_scan`                  | **IDENTIFIED** | `tenable_vulnerability_finding` |
+  | `tenable_scan`                  | **IDENTIFIED** | `tenable_vulnerability`         |
+  | `tenable_scan`                  | **SCANS**      | `<host>`                        |
+  | `tenable_user`                  | **OWNS**       | `tenable_scan`                  |
+  | `tenable_vulnerability_finding` | **IS**         | `vulnerability`                 |
+
 - Removed support for ingesting the following mapped relationships:
 
   | Source         | \_class   | Target   |

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -78,39 +78,32 @@ https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
 
 The following entities are created:
 
-| Resources                  | Entity `_type`                       | Entity `_class`         |
-| -------------------------- | ------------------------------------ | ----------------------- |
-| Account                    | `tenable_account`                    | `Account`               |
-| Asset                      | `tenable_asset`                      | `Record`                |
-| Container                  | `tenable_container`                  | `Image`                 |
-| Container Finding          | `tenable_container_finding`          | `Finding`               |
-| Container Malware          | `tenable_container_malware`          | `Finding`               |
-| Container Report           | `tenable_container_report`           | `Assessment`            |
-| Container Unwanted Program | `tenable_container_unwanted_program` | `Finding`               |
-| Scan                       | `tenable_scan`                       | `Assessment`, `Service` |
-| User                       | `tenable_user`                       | `User`                  |
-| Vulnerability              | `tenable_vulnerability`              | `Finding`               |
-| Vulnerability Finding      | `tenable_vulnerability_finding`      | `Finding`               |
+| Resources                  | Entity `_type`                       | Entity `_class` |
+| -------------------------- | ------------------------------------ | --------------- |
+| Account                    | `tenable_account`                    | `Account`       |
+| Asset                      | `tenable_asset`                      | `Record`        |
+| Container                  | `tenable_container`                  | `Image`         |
+| Container Finding          | `tenable_container_finding`          | `Finding`       |
+| Container Malware          | `tenable_container_malware`          | `Finding`       |
+| Container Report           | `tenable_container_report`           | `Assessment`    |
+| Container Unwanted Program | `tenable_container_unwanted_program` | `Finding`       |
+| User                       | `tenable_user`                       | `User`          |
+| Vulnerability              | `tenable_vulnerability`              | `Finding`       |
 
 ### Relationships
 
 The following relationships are created/mapped:
 
-| Source Entity `_type`           | Relationship `_class` | Target Entity `_type`                                         |
-| ------------------------------- | --------------------- | ------------------------------------------------------------- |
-| `tenable_account`               | **HAS**               | `tenable_asset`                                               |
-| `tenable_account`               | **HAS**               | `tenable_container`                                           |
-| `tenable_account`               | **HAS**               | `tenable_user`                                                |
-| `tenable_asset`                 | **HAS**               | `tenable_vulnerability`                                       |
-| `tenable_container`             | **HAS**               | `tenable_container_report`                                    |
-| `tenable_container_report`      | **IDENTIFIED**        | `tenable_container_finding`                                   |
-| `tenable_container_report`      | **IDENTIFIED**        | `tenable_container_malware`                                   |
-| `tenable_container_report`      | **IDENTIFIED**        | `tenable_container_unwanted_program`                          |
-| `tenable_scan`                  | **IDENTIFIED**        | `tenable_vulnerability_finding`                               |
-| `tenable_scan`                  | **IDENTIFIED**        | `tenable_vulnerability`                                       |
-| `tenable_scan`                  | **SCANS**             | `aws_instance,azure_vm,google_compute_instance,tenable_asset` |
-| `tenable_user`                  | **OWNS**              | `tenable_scan`                                                |
-| `tenable_vulnerability_finding` | **IS**                | `vulnerability`                                               |
+| Source Entity `_type`      | Relationship `_class` | Target Entity `_type`                |
+| -------------------------- | --------------------- | ------------------------------------ |
+| `tenable_account`          | **HAS**               | `tenable_asset`                      |
+| `tenable_account`          | **HAS**               | `tenable_container`                  |
+| `tenable_account`          | **HAS**               | `tenable_user`                       |
+| `tenable_asset`            | **HAS**               | `tenable_vulnerability`              |
+| `tenable_container`        | **HAS**               | `tenable_container_report`           |
+| `tenable_container_report` | **IDENTIFIED**        | `tenable_container_finding`          |
+| `tenable_container_report` | **IDENTIFIED**        | `tenable_container_malware`          |
+| `tenable_container_report` | **IDENTIFIED**        | `tenable_container_unwanted_program` |
 
 ### Mapped Relationships
 

--- a/src/steps/vulnerabilities/index.ts
+++ b/src/steps/vulnerabilities/index.ts
@@ -1,7 +1,6 @@
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationError,
   IntegrationStepExecutionContext,
   RelationshipClass,
   Step,
@@ -11,26 +10,15 @@ import {
   entities,
   MappedRelationships,
   relationships,
-  SetDataKeys,
   StepIds,
 } from '../../constants';
-import { createVulnerabilityExportCache } from '../../tenable/createVulnerabilityExportCache';
 import TenableClient from '../../tenable/TenableClient';
 import {
   AssetExport,
-  RecentScanSummary,
-  ScanStatus,
-  User,
   VulnerabilityExport,
 } from '@jupiterone/tenable-client-nodejs';
 import {
   createTargetHostEntity,
-  createScanEntity,
-  createScanFindingRelationship,
-  createScanVulnerabilityRelationship,
-  createUserScanRelationship,
-  createVulnerabilityFindingEntity,
-  createVulnerabilityFindingRelationship,
   createAssetEntity,
   createVulnerabilityEntity,
   createTargetCveEntities,
@@ -41,79 +29,6 @@ import {
 } from '../../utils/targetEntities';
 import { getAccount } from '../../initializeContext';
 import { createAccountEntity } from '../account/converters';
-
-export async function fetchScans(
-  context: IntegrationStepExecutionContext<TenableIntegrationConfig>,
-): Promise<void> {
-  const client = new TenableClient({
-    logger: context.logger,
-    accessToken: context.instance.config.accessKey,
-    secretToken: context.instance.config.secretKey,
-  });
-
-  const scans = await client.fetchScans();
-
-  for (const scan of scans) {
-    await context.jobState.addEntity(createScanEntity(scan));
-  }
-}
-
-export async function buildUserScanRelationships({
-  jobState,
-  logger,
-}: IntegrationStepExecutionContext<TenableIntegrationConfig>): Promise<void> {
-  const users = await jobState.getData<User[]>(SetDataKeys.USERS);
-
-  if (!users) {
-    logger.warn(
-      {
-        dataKey: SetDataKeys.USERS,
-      },
-      'Could not retrieve list of users from job state. Cannot build scan -> user relationships.',
-    );
-    throw new IntegrationError({
-      code: 'MISSING_USER_DATA',
-      message: 'Cannot build scan -> user relationships; user data is missing.',
-    });
-  }
-
-  await jobState.iterateEntities(
-    { _type: entities.SCAN._type },
-    async (scanEntity) => {
-      const scan = getRawData<RecentScanSummary>(scanEntity);
-      if (!scan) {
-        logger.warn(
-          {
-            scanKey: scanEntity._key,
-          },
-          'Could not get raw data from scan.',
-        );
-        return;
-      }
-
-      const user = findUser(users, scan.owner);
-
-      if (!user) {
-        logger.warn(
-          {
-            'scan.owner': scan.owner,
-          },
-          'Could not find scan owner by username',
-        );
-        return;
-      }
-
-      await jobState.addRelationship(createUserScanRelationship(user, scan));
-    },
-  );
-  await jobState.setData(SetDataKeys.USERS, undefined);
-}
-
-function findUser(users: User[], username: string): User | undefined {
-  return users.find((user) => user.username === username);
-}
-
-type AssetMap = Map<string, AssetExport>;
 
 export async function fetchAssets(
   context: IntegrationStepExecutionContext<TenableIntegrationConfig>,
@@ -255,155 +170,9 @@ export async function buildVulnerabilityCveRelationships(
   );
 }
 
-export async function fetchScanDetails(
-  context: IntegrationStepExecutionContext<TenableIntegrationConfig>,
-): Promise<void> {
-  const { jobState, logger, instance } = context;
-  const provider = new TenableClient({
-    logger: logger,
-    accessToken: instance.config.accessKey,
-    secretToken: instance.config.secretKey,
-  });
-
-  const assetMap = await jobState.getData<AssetMap>(SetDataKeys.ASSET_MAP);
-
-  const vulnerabilityCache = await createVulnerabilityExportCache(
-    context.logger,
-    provider,
-  );
-
-  await jobState.iterateEntities(
-    { _type: entities.SCAN._type },
-    async (scanEntity) => {
-      const scan = getRawData<RecentScanSummary>(scanEntity);
-      if (!scan) {
-        logger.warn(
-          {
-            scanKey: scanEntity._key,
-          },
-          'Could not get raw data from scan.',
-        );
-        return;
-      }
-
-      if (scan.status === ScanStatus.Completed) {
-        const scanDetail = await provider.fetchScanDetail(scan);
-        if (scanDetail) {
-          if (scanDetail.vulnerabilities) {
-            const vulnerabilities = scanDetail.vulnerabilities;
-            for (const vuln of vulnerabilities) {
-              await context.jobState.addRelationship(
-                createScanVulnerabilityRelationship(scan, vuln),
-              );
-            }
-          }
-          // If the scan detail is archived any calls
-          // to sync the host details will give a 404 until
-          // we add the export functionality requested by
-          // Tenable. POST /scans/scan_id/export
-          if (scanDetail.hosts && !scanDetail.info.is_archived) {
-            logger.info(
-              {
-                scanDetailHosts: scanDetail.hosts.length,
-              },
-              'Processing scan detail hosts...',
-            );
-            for (const host of scanDetail.hosts) {
-              const scanHostVulnerabilities =
-                await provider.fetchScanHostVulnerabilities(
-                  scan.id,
-                  host.host_id,
-                );
-
-              const assetUuid = host.uuid;
-
-              const asset = assetMap?.get(assetUuid);
-              if (asset) {
-                await jobState.addRelationship(
-                  createRelationshipToTargetEntity({
-                    from: scanEntity,
-                    _class: RelationshipClass.SCANS,
-                    to: createTargetHostEntity(asset),
-                  }),
-                );
-              } else {
-                logger.info(
-                  {
-                    assetUuid,
-                    scanId: scan.id,
-                  },
-                  'Could not find asset listed in scan.',
-                );
-              }
-
-              logger.info(
-                {
-                  assetUuid,
-                  scanHostVulnerabilities: scanHostVulnerabilities.length,
-                },
-                'Processing host vulnerabilities discovered by recent scan...',
-              );
-
-              for (const vulnerability of scanHostVulnerabilities) {
-                let vulnerabilityExport: VulnerabilityExport | undefined;
-                /* istanbul ignore next */
-                if (assetUuid) {
-                  vulnerabilityExport =
-                    vulnerabilityCache.findVulnerabilityExportByAssetPluginUuid(
-                      assetUuid,
-                      vulnerability.plugin_id,
-                    );
-                }
-
-                await context.jobState.addEntity(
-                  createVulnerabilityFindingEntity({
-                    scan,
-                    asset,
-                    assetUuid,
-                    vulnerability,
-                    vulnerabilityExport,
-                  }),
-                );
-
-                await context.jobState.addRelationship(
-                  createVulnerabilityFindingRelationship({
-                    scan,
-                    assetUuid,
-                    vulnerability,
-                  }),
-                );
-
-                await context.jobState.addRelationship(
-                  createScanFindingRelationship({
-                    scan,
-                    assetUuid,
-                    vulnerability,
-                  }),
-                );
-              }
-
-              logger.info(
-                'Processing host vulnerabilities discovered by recent scan completed.',
-              );
-            }
-          }
-        }
-      }
-    },
-  );
-}
-
 export const scanSteps: Step<
   IntegrationStepExecutionContext<TenableIntegrationConfig>
 >[] = [
-  {
-    id: StepIds.SCANS,
-    name: 'Fetch Scans',
-    entities: [entities.SCAN],
-    relationships: [],
-    dependsOn: [],
-    executionHandler: fetchScans,
-  },
   {
     id: StepIds.ASSETS,
     name: 'Fetch Assets',
@@ -438,26 +207,5 @@ export const scanSteps: Step<
     mappedRelationships: [MappedRelationships.VULNERABILITY_IS_CVE],
     dependsOn: [StepIds.VULNERABILITIES],
     executionHandler: buildVulnerabilityCveRelationships,
-  },
-  {
-    id: StepIds.SCAN_DETAILS,
-    name: 'Fetch Scan Details',
-    entities: [entities.VULNERABILITY, entities.VULN_FINDING],
-    relationships: [
-      relationships.SCAN_IDENTIFIED_FINDING,
-      relationships.SCAN_IDENTIFIED_VULNERABILITY,
-      relationships.FINDING_IS_VULNERABILITY,
-      relationships.SCAN_SCANS_ASSET,
-    ],
-    dependsOn: [StepIds.SCANS, StepIds.ASSETS],
-    executionHandler: fetchScanDetails,
-  },
-  {
-    id: StepIds.USER_SCAN_RELATIONSHIPS,
-    name: 'Fetch User Scan Relationships',
-    entities: [],
-    relationships: [relationships.USER_OWNS_SCAN],
-    dependsOn: [StepIds.SCANS, StepIds.USERS],
-    executionHandler: buildUserScanRelationships,
   },
 ];


### PR DESCRIPTION
```
### Remvoved

- Removed support for ingesting the following entities:

  | Resources             | Entity `_type`                  | Entity `_class`         |
  | --------------------- | ------------------------------- | ----------------------- |
  | Scan                  | `tenable_scan`                  | `Assessment`, `Service` |
  | Vulnerability Finding | `tenable_vulnerability_finding` | `Finding`               |

- Removed support for ingesting the following relationships:

  | Source                          | \_class        | Target                          |
  | ------------------------------- | -------------- | ------------------------------- |
  | `tenable_scan`                  | **IDENTIFIED** | `tenable_vulnerability_finding` |
  | `tenable_scan`                  | **IDENTIFIED** | `tenable_vulnerability`         |
  | `tenable_scan`                  | **SCANS**      | `<host>`                        |
  | `tenable_user`                  | **OWNS**       | `tenable_scan`                  |
  | `tenable_vulnerability_finding` | **IS**         | `vulnerability`                 |
```

**Previous:**
![Screen Shot 2021-09-02 at 10 50 37 AM](https://user-images.githubusercontent.com/15333061/131865893-3e76e301-3f8d-4524-be0e-b446e7da330a.png)

**Current:**
![Screen Shot 2021-09-02 at 10 51 20 AM](https://user-images.githubusercontent.com/15333061/131866042-c9999e3d-ab3f-480b-b4f2-7c8b19bc06b9.png)
