### PR TITLE
Skip creating target `host` entities

### DIFF
--- a/src/steps/vulnerabilities/converters.ts
+++ b/src/steps/vulnerabilities/converters.ts
@@ -91,6 +91,7 @@ export function createTargetHostEntity(data: AssetExport): TargetEntity {
   let targetFilter;
 
   if (data.aws_ec2_instance_id) {
+    // TODO test EC2 instance mapping and attempt to build _key property
     targetFilter = {
       instanceId: data.aws_ec2_instance_id,
       _type: 'aws_instance',
@@ -102,6 +103,7 @@ export function createTargetHostEntity(data: AssetExport): TargetEntity {
       _type: 'azure_vm',
     };
   } else if (data.gcp_instance_id) {
+    // TODO test GCP instance mapping and attempt to build _key property
     targetFilter = {
       id: data.gcp_instance_id,
       projectId: data.gcp_project_id,
@@ -129,6 +131,7 @@ export function createTargetHostEntity(data: AssetExport): TargetEntity {
       ...targetFilter,
     },
     targetFilterKeys: [Object.keys(targetFilter)],
+    skipTargetCreation: true,
   };
 }
 

--- a/src/utils/targetEntities.ts
+++ b/src/utils/targetEntities.ts
@@ -11,6 +11,7 @@ import {
 export type TargetEntity = {
   targetEntity: TargetEntityProperties & { _key: string; _type: string };
   targetFilterKeys: TargetFilterKey[];
+  skipTargetCreation?: boolean;
 };
 
 export function createRelationshipToTargetEntity(options: {


### PR DESCRIPTION
**Do not** create target `aws_instance`, `azure_vm`, or `google_compute_instance` entities if they do not exist.